### PR TITLE
enabled shutters for use with beam

### DIFF
--- a/profile_2bmb/startup/20-signals.py
+++ b/profile_2bmb/startup/20-signals.py
@@ -43,13 +43,13 @@ aps_current = aps.current
 
 if aps.inUserOperations:
     # no scans until A_shutter is open
-    ##fdc suspend_A_shutter = bluesky.suspenders.SuspendFloor(A_shutter.pss_state, 1)
+    suspend_A_shutter = bluesky.suspenders.SuspendFloor(A_shutter.pss_state, 1)
     #suspend_A_shutter.install(RE)
-    ##fdc RE.install_suspender(suspend_A_shutter)
+    RE.install_suspender(suspend_A_shutter)
 
     # no scans if aps.current is too low
-    ##fdc suspend_APS_current = bluesky.suspenders.SuspendFloor(aps_current, 2, resume_thresh=10)
-    ##fdc RE.install_suspender(suspend_APS_current)
+    suspend_APS_current = bluesky.suspenders.SuspendFloor(aps_current, 2, resume_thresh=10)
+    RE.install_suspender(suspend_APS_current)
     pass
 
 #pf4 = APS_devices.DualPf4FilterBox("2bmb:pf4:", name="pf4")

--- a/profile_2bmb/startup/30-busy_fly_scan.py
+++ b/profile_2bmb/startup/30-busy_fly_scan.py
@@ -92,8 +92,7 @@ def measure_flats(det, shutter, quantity, expected, samStage, samPos):
     priorPosition = samStage.position
     yield from bps.sleep(1)     # arbitrary, shutter won't move without it
     yield from bps.mv(
-##fdc        shutter, "open",
-        shutter, "close",
+        shutter, "open",
         samStage, samPos,
         det.cam.trigger_mode, "Internal",
         det.cam.frame_type, 2,  # white
@@ -129,8 +128,7 @@ def tomo_scan(*, start=0, stop=180, numProjPerSweep=1500, slewSpeed=5, accl=1, s
     # assigns darks, whites, images to proper datasets in HDF5 file
     det = pg3_det
     try:
-        # APS_devices.AD_setup_FrameType(
-        AD_setup_FrameType(
+        APS_devices.AD_setup_FrameType(
             EPICS_PV_prefix["PG3 PointGrey Grasshopper3"], 
             scheme="DataExchange"
         )
@@ -264,7 +262,7 @@ def tomo_scan(*, start=0, stop=180, numProjPerSweep=1500, slewSpeed=5, accl=1, s
             )
 
         # !!! moves the shutter !!!
-##fdc        yield from bps.abs_set(shutter, "open", group="shutter")
+        yield from bps.abs_set(shutter, "open", group="shutter")
 
         yield from bps.stop(rotStage)
         yield from motor_set_modulo(rotStage, 360.0)


### PR DESCRIPTION
I removed comment so I can use it back in ops. 
All works (hdf files are correct, including theta) except at the end of the scan I get the error below.
 
In [1]: RE(user_tomo_scan(acquire_time=0.01, iterations=3), comment="my tomo fly scan", sample="wood stick")
*************************************
Total # of proj:  1500
Exposure Time:  0.01 s
Readout Time:  0.004 s
Angular Range:  180.0 degrees
Camera X size:  1920
Blur Error:  0.00107424245552 pixels
*************************************
Rot Speed: :  8.57142857131 degrees/s
Scan Time::  21.0000000003 s
Frame Rate:  71.4285714275 fps
*************************************
computed rotation speed: 8.571428571305242 degrees / s
computed blur angle/image: 0.08571428571305242 degrees
computed blur pixel/image: 0.001074242455501917 pixels
iterations: 3
10 Darks, Shutter OFF
10 Flats, Shutter ON                                                                                                    
2018-10-09 19:30:42.682081 taxi time: 5.200307369232178 s                                                               
0.00s - flying   x = -0.0000  y = 5.0000  r = -36.8400  theta = 323.1600  image # 0                                     
5.01s - flying   x = -0.0000  y = 5.0000  r = -26.5860  theta = 333.4140  image # 0
8.63s - flying   x = -0.0000  y = 5.0000  r = -0.7175  theta = 359.2825  image # 1
13.64s - flying   x = -0.0000  y = 5.0000  r = 42.3805  theta = 42.3805  image # 359
18.65s - flying   x = -0.0000  y = 5.0000  r = 85.1705  theta = 85.1705  image # 717
23.65s - flying   x = -0.0000  y = 5.0000  r = 128.0045  theta = 128.0045  image # 1074
28.66s - flying   x = -0.0000  y = 5.0000  r = 171.8225  theta = 171.8225  image # 1432
33.67s - flying   x = -0.0000  y = 5.0000  r = 208.5165  theta = 208.5165  image # 1500
38.21s - flying   x = -0.0000  y = 5.0000  r = 216.7350  theta = 216.7350  image # 1500
2018-10-09 19:31:20.957744 fly time: 38.21751523017883 s
Adding /exchange/theta to /local/user2bmb/mona/2018/10/09/bfd675a4-864c-4874-a4b5_000000.h5
---------------------------------------------------------------------------                                             
FailedStatus                              Traceback (most recent call last)
~/Apps/BlueSky/lib/python3.6/site-packages/bluesky/preprocessors.py in contingency_wrapper(plan, except_plan, else_plan, final_plan, pause_for_debug)
    561     try:
--> 562         ret = yield from plan
    563     except GeneratorExit:

~/Apps/BlueSky/lib/python3.6/site-packages/bluesky/preprocessors.py in dec_inner(*inner_args, **inner_kwargs)
    640                 if cleanup:
--> 641                     yield from ensure_generator(final_plan_instance)
    642             return ret

/home/beams8/USER2BMB/.ipython/profile_2bmb/startup/30-busy_fly_scan.py in cleanup()
    183         # clear the stop flag
--> 184         yield from bps.abs_set(mona.stop_acquisition, 0)
    185 
